### PR TITLE
menu pops by hovering "?" is now inside the screen

### DIFF
--- a/src/components/NavigationBar/index.js
+++ b/src/components/NavigationBar/index.js
@@ -95,6 +95,7 @@ const TopRightMenuContainer = styled.div`
   justify-content: center;
   align-items: center;
   margin-top: 1px;
+  margin-left:-30px;
 `;
 
 const SusiLogoContainer = styled.div`


### PR DESCRIPTION
fixed the issue #2671



**Changes: Now the menu that pops on hovering on "?" is completely inside the display console**



Screenshots of the change: [Add screenshots depicting the changes.]
**before the bug removing the menu use to look  like**
![susi1](https://user-images.githubusercontent.com/48439116/61888690-9e87eb00-af21-11e9-9bf9-753535d265a4.jpg)


**After bug removing**
![susi3](https://user-images.githubusercontent.com/48439116/61888749-b2335180-af21-11e9-9383-e0a0304c5b4f.jpg)





